### PR TITLE
Improvement: removal of first generic parameter

### DIFF
--- a/Demo/Classes/Presentation/Controllers/AutolayoutCellsController.swift
+++ b/Demo/Classes/Presentation/Controllers/AutolayoutCellsController.swift
@@ -30,7 +30,7 @@ class AutolayoutCellsController: UIViewController {
         while rows <= 10 {
             rows += 1
             
-            let row = TableRow<Void, AutolayoutTableViewCell>(item: ())
+            let row = TableRow<AutolayoutTableViewCell>(item: ())
             section += row
         }
         

--- a/Demo/Classes/Presentation/Controllers/MainController.swift
+++ b/Demo/Classes/Presentation/Controllers/MainController.swift
@@ -24,7 +24,7 @@ class MainController: UIViewController {
         
         title = "TableKit"
 
-        let clickAction = TableRowAction<String, ConfigurableTableViewCell>(.click) { [weak self] (data) in
+        let clickAction = TableRowAction<ConfigurableTableViewCell>(.click) { [weak self] (data) in
             
             switch data.path.row {
             case 0:
@@ -40,9 +40,9 @@ class MainController: UIViewController {
         
         let rows: [Row] = [
 
-            TableRow<String, ConfigurableTableViewCell>(item: "Autolayout cells", actions: [clickAction]),
-            TableRow<String, ConfigurableTableViewCell>(item: "Row builder cells", actions: [clickAction]),
-            TableRow<String, ConfigurableTableViewCell>(item: "Nib cells", actions: [clickAction])
+            TableRow<ConfigurableTableViewCell>(item: "Autolayout cells", actions: [clickAction]),
+            TableRow<ConfigurableTableViewCell>(item: "Row builder cells", actions: [clickAction]),
+            TableRow<ConfigurableTableViewCell>(item: "Nib cells", actions: [clickAction])
         ]
 
         // automatically creates a section, also could be used like tableDirector.append(rows: rows)

--- a/Demo/Classes/Presentation/Controllers/NibCellsController.swift
+++ b/Demo/Classes/Presentation/Controllers/NibCellsController.swift
@@ -23,11 +23,11 @@ class NibCellsController: UITableViewController {
         
         let numbers = [1000, 2000, 3000, 4000, 5000]
         
-        let shouldHighlightAction = TableRowAction<Int, NibTableViewCell>(.shouldHighlight) { (_) -> Bool in
+        let shouldHighlightAction = TableRowAction<NibTableViewCell>(.shouldHighlight) { (_) -> Bool in
             return false
         }
         
-        let rows: [Row] = numbers.map { TableRow<Int, NibTableViewCell>(item: $0, actions: [shouldHighlightAction]) }
+        let rows: [Row] = numbers.map { TableRow<NibTableViewCell>(item: $0, actions: [shouldHighlightAction]) }
         
         tableDirector.append(rows: rows)
     }

--- a/Demo/Classes/Presentation/Controllers/RowBuilderCellsController.swift
+++ b/Demo/Classes/Presentation/Controllers/RowBuilderCellsController.swift
@@ -26,12 +26,12 @@ class RowBuilderCellsController: UIViewController {
         
         let numbers = ["1", "2", "3", "4", "5"]
         
-        let clickAction = TableRowAction<String, ConfigurableTableViewCell>(.click) { (data) in
+        let clickAction = TableRowAction<ConfigurableTableViewCell>(.click) { (data) in
             
             print(data.item)
         }
         
-        let rowBuilder = TableRowBuilder<String, ConfigurableTableViewCell>(items: numbers, actions: [clickAction])
+        let rowBuilder = TableRowBuilder<ConfigurableTableViewCell>(items: numbers, actions: [clickAction])
         
         let section = TableSection(headerTitle: "Header title", footerTitle: "Footer title")
         

--- a/Sources/TableRow.swift
+++ b/Sources/TableRow.swift
@@ -43,10 +43,10 @@ public protocol Row: RowConfigurable, RowActionable, RowHashable {
     var defaultHeight: CGFloat { get }
 }
 
-public class TableRow<ItemType, CellType: ConfigurableCell where CellType.T == ItemType, CellType: UITableViewCell>: Row {
-
+public class TableRow<CellType: ConfigurableCell where CellType: UITableViewCell>: Row {
+    typealias ItemType = CellType.T
     public let item: ItemType
-    private lazy var actions = [String: TableRowAction<ItemType, CellType>]()
+    private lazy var actions = [String: TableRowAction<CellType>]()
     
     public var hashValue: Int {
         return ObjectIdentifier(self).hashValue
@@ -64,7 +64,7 @@ public class TableRow<ItemType, CellType: ConfigurableCell where CellType.T == I
         return CellType.defaultHeight() ?? UITableViewAutomaticDimension
     }
     
-    public init(item: ItemType, actions: [TableRowAction<ItemType, CellType>]? = nil) {
+    public init(item: ItemType, actions: [TableRowAction<CellType>]? = nil) {
         
         self.item = item
         actions?.forEach { self.actions[$0.type.key] = $0 }
@@ -88,13 +88,13 @@ public class TableRow<ItemType, CellType: ConfigurableCell where CellType.T == I
     
     // MARK: - actions -
     
-    public func action(action: TableRowAction<ItemType, CellType>) -> Self {
+    public func action(action: TableRowAction<CellType>) -> Self {
 
         actions[action.type.key] = action
         return self
     }
     
-    public func action<T>(type: TableRowActionType, handler: (data: TableRowActionData<ItemType, CellType>) -> T) -> Self {
+    public func action<T>(type: TableRowActionType, handler: (data: TableRowActionData<CellType>) -> T) -> Self {
         
         actions[type.key] = TableRowAction(type, handler: handler)
         return self

--- a/Sources/TableRowAction.swift
+++ b/Sources/TableRowAction.swift
@@ -42,8 +42,8 @@ public enum TableRowActionType {
     }
 }
 
-public class TableRowActionData<ItemType, CellType: ConfigurableCell where CellType.T == ItemType, CellType: UITableViewCell> {
-
+public class TableRowActionData<CellType: ConfigurableCell where CellType: UITableViewCell> {
+    typealias ItemType = CellType.T
     public let item: ItemType
     public let cell: CellType?
     public let path: NSIndexPath
@@ -58,18 +58,18 @@ public class TableRowActionData<ItemType, CellType: ConfigurableCell where CellT
     }
 }
 
-public class TableRowAction<ItemType, CellType: ConfigurableCell where CellType.T == ItemType, CellType: UITableViewCell> {
-
+public class TableRowAction<CellType: ConfigurableCell where CellType: UITableViewCell> {
+    typealias ItemType = CellType.T
     public let type: TableRowActionType
-    private let handler: ((data: TableRowActionData<ItemType, CellType>) -> Any?)
+    private let handler: ((data: TableRowActionData<CellType>) -> Any?)
 
-    public init(_ type: TableRowActionType, handler: (data: TableRowActionData<ItemType, CellType>) -> Void) {
+    public init(_ type: TableRowActionType, handler: (data: TableRowActionData<CellType>) -> Void) {
 
         self.type = type
         self.handler = handler
     }
     
-    public init<T>(_ type: TableRowActionType, handler: (data: TableRowActionData<ItemType, CellType>) -> T) {
+    public init<T>(_ type: TableRowActionType, handler: (data: TableRowActionData<CellType>) -> T) {
 
         self.type = type
         self.handler = handler

--- a/Sources/TableRowBuilder.swift
+++ b/Sources/TableRowBuilder.swift
@@ -25,16 +25,16 @@ public protocol RowBuilder {
     func rows() -> [Row]?
 }
 
-public class TableRowBuilder<ItemType, CellType: ConfigurableCell where CellType.T == ItemType, CellType: UITableViewCell>: RowBuilder {
-
+public class TableRowBuilder<CellType: ConfigurableCell where CellType: UITableViewCell>: RowBuilder {
+    typealias ItemType = CellType.T
     public var items: [ItemType]?
-    public var actions: [TableRowAction<ItemType, CellType>]?
+    public var actions: [TableRowAction<CellType>]?
     
     public init(handler: (TableRowBuilder) -> ()) {
         handler(self)
     }
     
-    public init(items: [ItemType], actions: [TableRowAction<ItemType, CellType>]? = nil) {
+    public init(items: [ItemType], actions: [TableRowAction<CellType>]? = nil) {
 
         self.items = items
         self.actions = actions
@@ -43,7 +43,7 @@ public class TableRowBuilder<ItemType, CellType: ConfigurableCell where CellType
     // MARK: - RowBuilder -
     
     public func rows() -> [Row]? {
-        return items?.map { TableRow<ItemType, CellType>(item: $0, actions: actions) }
+        return items?.map { TableRow<CellType>(item: $0, actions: actions) }
     }
 }
 

--- a/Tests/TableKitTests.swift
+++ b/Tests/TableKitTests.swift
@@ -95,7 +95,7 @@ class TabletTests: XCTestCase {
         
         let data = TestData(title: "title")
 
-        let row = TableRow<TestData, TestTableViewCell>(item: data)
+        let row = TableRow<TestTableViewCell>(item: data)
         
         testController.tableDirector += row
         testController.tableView.reloadData()
@@ -112,7 +112,7 @@ class TabletTests: XCTestCase {
         
         let data = [TestData(title: "1"), TestData(title: "2"), TestData(title: "3")]
         
-        let rows: [Row] = data.map({ TableRow<TestData, TestTableViewCell>(item: $0) })
+        let rows: [Row] = data.map({ TableRow<TestTableViewCell>(item: $0) })
         
         testController.tableDirector += rows
         testController.tableView.reloadData()
@@ -130,7 +130,7 @@ class TabletTests: XCTestCase {
     
     func testTableSectionCreatesSectionWithHeaderAndFooterTitles() {
         
-        let row = TableRow<TestData, TestTableViewCell>(item: TestData(title: "title"))
+        let row = TableRow<TestTableViewCell>(item: TestData(title: "title"))
         
         let sectionHeaderTitle = "Header Title"
         let sectionFooterTitle = "Footer Title"
@@ -149,7 +149,7 @@ class TabletTests: XCTestCase {
     
     func testTableSectionCreatesSectionWithHeaderAndFooterViews() {
         
-        let row = TableRow<TestData, TestTableViewCell>(item: TestData(title: "title"))
+        let row = TableRow<TestTableViewCell>(item: TestData(title: "title"))
         
         let sectionHeaderView = UIView()
         let sectionFooterView = UIView()
@@ -171,7 +171,7 @@ class TabletTests: XCTestCase {
 
         let expectation = expectationWithDescription("cell action")
 
-        let row = TableRow<TestData, TestTableViewCell>(item: TestData(title: "title"))
+        let row = TableRow<TestTableViewCell>(item: TestData(title: "title"))
             .action(TableRowAction(.custom(TestTableViewCellOptions.CellAction)) { (data) in
                 
                 XCTAssertNotNil(data.cell, "Action data should have a cell")


### PR DESCRIPTION
The first generic parameter is not needed because it could be infered from CellType.T