### PR TITLE
Implement tableView:canMoveRowAt:indexPath method

### DIFF
--- a/Sources/TableDirector.swift
+++ b/Sources/TableDirector.swift
@@ -307,6 +307,10 @@ open class TableDirector: NSObject, UITableViewDataSource, UITableViewDelegate {
         }
     }
     
+    open func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        return invoke(action: .canMove, cell: tableView.cellForRow(at: indexPath), indexPath: indexPath) as? Bool ?? true
+    }
+    
     open func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         invoke(action: .move, cell: tableView.cellForRow(at: sourceIndexPath), indexPath: sourceIndexPath, userInfo: [TableKitUserInfoKeys.CellMoveDestinationIndexPath: destinationIndexPath])
     }

--- a/Sources/TableKit.swift
+++ b/Sources/TableKit.swift
@@ -74,6 +74,7 @@ public enum TableRowActionType {
     case height
     case canEdit
     case configure
+    case canMove
     case move
     case custom(String)
     


### PR DESCRIPTION
I would like to disable moving the cell, so I have added method tableView:canMoveRowAt:indexPath