### PR TITLE
Updated Swift tools version and added missing requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,20 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-    name: "TableKit"
+    name: "TableKit",
+
+    products: [
+        .library(
+            name: "TableKit",
+            targets: ["TableKit"]),
+    ],
+
+    targets: [
+        .target(
+            name: "TableKit",
+            path: "Sources")
+    ]
 )


### PR DESCRIPTION
I've been using TableKit in all my projects with CocoaPods (thank you!) but recently tried to use it in a new project with SwiftPM in Xcode 11 beta 7 and it wouldn't work.

I'm still getting [this error](https://github.com/kiliankoe/DVB/issues/34) and don't know how to fix it (the error message says the requirement it can't match is `2.9.0..<3.0.0`, which makes no sense because there is a 2.9.0 tag and Xcode is recognising that as the latest version automatically). I've tried using version 2.8.0 as well, but get the same error.

However, with the changes I've made to `Package.swift` in this PR, Xcode *will* add the package if I use the hash of the last commit. So I think these changes did need to be made to update the package file, but there's an outstanding issue with tags that I'm not sure about.