### PR TITLE
Add support for iOS 13 actions

### DIFF
--- a/Sources/TableDirector.swift
+++ b/Sources/TableDirector.swift
@@ -317,6 +317,31 @@ open class TableDirector: NSObject, UITableViewDataSource, UITableViewDelegate {
         return indexPath
     }
 
+    @available(iOS 13.0, *)
+    open func tableView(
+        _ tableView: UITableView,
+        shouldBeginMultipleSelectionInteractionAt indexPath: IndexPath) -> Bool
+    {
+        invoke(action: .shouldBeginMultipleSelection, cell: tableView.cellForRow(at: indexPath), indexPath: indexPath) as? Bool ?? false
+    }
+
+    @available(iOS 13.0, *)
+    open func tableView(
+        _ tableView: UITableView,
+        didBeginMultipleSelectionInteractionAt indexPath: IndexPath)
+    {
+        invoke(action: .didBeginMultipleSelection, cell: tableView.cellForRow(at: indexPath), indexPath: indexPath)
+    }
+    
+    @available(iOS 13.0, *)
+    open func tableView(
+        _ tableView: UITableView,
+        contextMenuConfigurationForRowAt indexPath: IndexPath,
+        point: CGPoint) -> UIContextMenuConfiguration?
+    {
+        invoke(action: .showContextMenu, cell: tableView.cellForRow(at: indexPath), indexPath: indexPath, userInfo: [TableKitUserInfoKeys.ContextMenuInvokePoint: point]) as? UIContextMenuConfiguration
+    }
+
     // MARK: - Row editing
     open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return sections[indexPath.section].rows[indexPath.row].isEditingAllowed(forIndexPath: indexPath)

--- a/Sources/TableKit.swift
+++ b/Sources/TableKit.swift
@@ -27,6 +27,7 @@ struct TableKitNotifications {
 public struct TableKitUserInfoKeys {
     public static let CellMoveDestinationIndexPath = "TableKitCellMoveDestinationIndexPath"
     public static let CellCanMoveProposedIndexPath = "CellCanMoveProposedIndexPath"
+    public static let ContextMenuInvokePoint = "ContextMenuInvokePoint"
 }
 
 public protocol RowConfigurable {
@@ -73,6 +74,8 @@ public enum TableRowActionType {
     case willDisplay
     case didEndDisplaying
     case shouldHighlight
+    case shouldBeginMultipleSelection
+    case didBeginMultipleSelection
     case height
     case canEdit
     case configure
@@ -80,6 +83,7 @@ public enum TableRowActionType {
     case canMove
     case canMoveTo
     case move
+    case showContextMenu
     case accessoryButtonTap
     case custom(String)
     


### PR DESCRIPTION
# Support for iOS 13
### Added two-finger cell selection actions
`shouldBeginMultipleSelection`, `didBeginMultipleSelection`

### Added action for displaying context menu
`showContextMenu `

Example usage:
```swift
if #available(iOS 13.0, *) {
    tableRow.on(.showContextMenu) { options -> UIContextMenuConfiguration? in
        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
            let key = TableKitUserInfoKeys.ContextMenuInvokePoint
            let point = options.userInfo?[key] as? CGPoint ?? CGPoint()

            let action = UIAction(title: "\(point.x):\(point.y)", handler: { _ in })

            return UIMenu(title: "Menu title", children: [action])
        }
    }
}
```
---
Looks like a solution for #58