### PR TITLE
Dynamic section header and footer views

### DIFF
--- a/Sources/TableDirector.swift
+++ b/Sources/TableDirector.swift
@@ -220,20 +220,23 @@ open class TableDirector: NSObject, UITableViewDataSource, UITableViewDelegate {
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard section < sections.count else { return nil }
         
-		return sections[section].headerView ?? sections[section].headerViewHandler?(section)
+		return sections[section].headerView ?? sections[section].headerViewHandler?()
     }
     
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard section < sections.count else { return nil }
         
-		return sections[section].footerView ?? sections[section].footerViewHandler?(section)
+		return sections[section].footerView ?? sections[section].footerViewHandler?()
     }
     
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         guard section < sections.count else { return 0 }
         
         let section = sections[section]
-        return section.headerHeight ?? section.headerView?.frame.size.height ?? UITableView.automaticDimension
+		return section.headerHeight
+			?? section.headerView?.frame.size.height
+			?? section.headerViewHandler?()?.frame.size.height
+			?? UITableView.automaticDimension
     }
     
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -242,6 +245,7 @@ open class TableDirector: NSObject, UITableViewDataSource, UITableViewDelegate {
         let section = sections[section]
         return section.footerHeight
             ?? section.footerView?.frame.size.height
+			?? section.footerViewHandler?()?.frame.size.height
             ?? UITableView.automaticDimension
     }
     

--- a/Sources/TableDirector.swift
+++ b/Sources/TableDirector.swift
@@ -220,13 +220,13 @@ open class TableDirector: NSObject, UITableViewDataSource, UITableViewDelegate {
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard section < sections.count else { return nil }
         
-        return sections[section].headerView
+		return sections[section].headerView ?? sections[section].headerViewHandler?(section)
     }
     
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard section < sections.count else { return nil }
         
-        return sections[section].footerView
+		return sections[section].footerView ?? sections[section].footerViewHandler?(section)
     }
     
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/Sources/TableSection.swift
+++ b/Sources/TableSection.swift
@@ -31,8 +31,8 @@ open class TableSection {
     open var headerView: UIView?
     open var footerView: UIView?
 	
-	open var headerViewHandler: ((Int) -> UIView?)?
-	open var footerViewHandler: ((Int) -> UIView?)?
+	open var headerViewHandler: (() -> UIView?)?
+	open var footerViewHandler: (() -> UIView?)?
     
     open var headerHeight: CGFloat? = nil
     open var footerHeight: CGFloat? = nil

--- a/Sources/TableSection.swift
+++ b/Sources/TableSection.swift
@@ -30,6 +30,9 @@ open class TableSection {
     
     open var headerView: UIView?
     open var footerView: UIView?
+	
+	open var headerViewHandler: ((Int) -> UIView?)?
+	open var footerViewHandler: ((Int) -> UIView?)?
     
     open var headerHeight: CGFloat? = nil
     open var footerHeight: CGFloat? = nil
@@ -62,7 +65,7 @@ open class TableSection {
         self.headerView = headerView
         self.footerView = footerView
     }
-
+	
     // MARK: - Public -
     
     open func clear() {

--- a/Tests/TableKitTests.swift
+++ b/Tests/TableKitTests.swift
@@ -177,12 +177,8 @@ class TableKitTests: XCTestCase {
         let sectionFooterView = UIView()
         
         let section = TableSection(rows: nil)
-		section.headerViewHandler = { sectionNumber in
-			return sectionHeaderView
-		}
-		section.footerViewHandler = { sectionNumber in
-			return sectionFooterView
-		}
+		section.headerViewHandler = { sectionHeaderView}
+		section.footerViewHandler = { sectionFooterView }
         section += row
         
         testController.tableDirector += section

--- a/Tests/TableKitTests.swift
+++ b/Tests/TableKitTests.swift
@@ -168,6 +168,32 @@ class TableKitTests: XCTestCase {
         XCTAssertTrue(testController.tableView.delegate?.tableView?(testController.tableView, viewForHeaderInSection: 0) == sectionHeaderView)
         XCTAssertTrue(testController.tableView.delegate?.tableView?(testController.tableView, viewForFooterInSection: 0) == sectionFooterView)
     }
+	
+	func testTableSectionCreatesSectionWithHeaderAndFooterViewsCallbacks() {
+        
+        let row = TableRow<TestTableViewCell>(item: TestData(title: "title"))
+        
+        let sectionHeaderView = UIView()
+        let sectionFooterView = UIView()
+        
+        let section = TableSection(rows: nil)
+		section.headerViewHandler = { sectionNumber in
+			return sectionHeaderView
+		}
+		section.footerViewHandler = { sectionNumber in
+			return sectionFooterView
+		}
+        section += row
+        
+        testController.tableDirector += section
+        testController.tableView.reloadData()
+        
+        XCTAssertTrue(testController.tableView.dataSource?.numberOfSections?(in: testController.tableView) == 1, "Table view should have a section")
+        XCTAssertTrue(testController.tableView.dataSource?.tableView(testController.tableView, numberOfRowsInSection: 0) == 1, "Table view should have certain number of rows in a section")
+        
+        XCTAssertTrue(testController.tableView.delegate?.tableView?(testController.tableView, viewForHeaderInSection: 0) == sectionHeaderView)
+        XCTAssertTrue(testController.tableView.delegate?.tableView?(testController.tableView, viewForFooterInSection: 0) == sectionFooterView)
+    }
 
     func testRowBuilderCustomActionInvokedAndSentUserInfo() {
 


### PR DESCRIPTION
Hey! I made this change in my fork because I had a large dataset with many sections. Creating sections and their header views at once caused a performance and memory problem, so I added the ability to have a callback to generate the header/footer when needed. This also allows the client to cache header/footer views and reuse them.